### PR TITLE
feat: add overlay and modal confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,35 @@
     label { display: block; margin-top: 10px; font-weight: bold; }
     input, textarea { width: 100%; padding: 8px; margin-top: 4px; box-sizing: border-box; }
     button.submit { margin-top: 20px; padding: 10px 20px; background-color: black; color: white; border: none; cursor: pointer; }
-    .confirmation, .success { margin-top: 20px; padding: 15px; border: 1px solid #ccc; background-color: #f9f9f9; }
+    #overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      display: none;
+      z-index: 999;
+    }
+
+    #confirmation {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      z-index: 1000;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+      padding: 20px;
+      display: none;
+    }
+
+    .success { margin-top: 20px; padding: 15px; border: 1px solid #ccc; background-color: #f9f9f9; }
     table { width: 100%; border-collapse: collapse; margin-top: 20px; }
     th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
     button.edit, button.delete, button.delete-client { background: none; border: none; color: blue; cursor: pointer; padding: 4px 8px; }
   </style>
 </head>
 <body>
+  <div id="overlay"></div>
   <h1>Stella Marina</h1>
 
   <nav>
@@ -204,8 +226,15 @@
             <li>Remarques : ${data.remarques || '—'}</li>
           </ul>
           <button id="confirmerBtn">Confirmer</button>
+          <button id="annulerBtn">Annuler</button>
         `;
+        document.getElementById("overlay").style.display = "block";
         document.getElementById("confirmation").style.display = "block";
+
+        document.getElementById("annulerBtn").addEventListener("click", () => {
+          document.getElementById("overlay").style.display = "none";
+          document.getElementById("confirmation").style.display = "none";
+        });
 
         document.getElementById("confirmerBtn").addEventListener("click", async () => {
           try {
@@ -229,6 +258,7 @@
               await updateClient(data.telephone, data.nom, data.prenom, data.email, data.dob);
             }
 
+            document.getElementById("overlay").style.display = "none";
             document.getElementById("confirmation").style.display = "none";
             document.getElementById("success").style.display = "block";
             document.getElementById("success").textContent = isEditing
@@ -240,6 +270,8 @@
 
           } catch (err) {
             alert("Erreur : " + err.message);
+            document.getElementById("overlay").style.display = "none";
+            document.getElementById("confirmation").style.display = "none";
           }
         });
       });


### PR DESCRIPTION
## Summary
- add overlay container and style modal confirmation dialog
- show/hide overlay and confirmation on form submit, confirmation, or cancellation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910c34b8dc83249f68202edb39ec48